### PR TITLE
READMEの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@
 |Column|Type|Options|Meaning|attention|
 |------|----|-------|-------|---------|
 |name|string||ブランド名|seedでブランド名を事前に流し込み、フォームで選択式にさせる。indexを貼る|
-|item_id|integer|null: false, foreign_key: true|Itemとの外部キー||
 
 ### Association
 - has_many :items
@@ -88,7 +87,6 @@
 |------|----|-------|-------|---------|
 |name|string||カテゴリー名|seedでカテゴリー名を事前に流し込み、フォームで選択式にさせる。indexを貼る|
 |ancestry|string||親子孫識別|ancestry gemを用いる|
-|item_id|integer|null: false, foreign_key: true|Itemとの外部キー||
 
 ### Association
 - has_many :items

--- a/README.md
+++ b/README.md
@@ -1,24 +1,94 @@
-# README
+# furima DB設計
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## usersテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|nickname|string|null: false|ニックネーム||
+|email|string|null: false, unique: true|メールアドレス||
+|password|string|null: false|パスワード|deviseで2度入力させる仕様にする|
+|last_name|string|null: false|名字|全角のみにバリデーション要|
+|last_name_furigana|string|null: false|みょうじ|全角のみにバリデーション要|
+|first_name|string|null: false|名前|全角のみにバリデーション要|
+|first_name_furigana|string|null: false|なまえ|全角のみにバリデーション要|
+|year_of_birth|integer|null: false, limit: 4|誕生年|フォームで選択式にする|
+|month_of_birth|integer|null: false, limit: 2|誕生月|フォームで選択式にする|
+|day_of_birth|integer|null: false, limit: 2|誕生日|フォームで選択式にする|
+|delivery_last_name|string|null: false|送付先名字||
+|delivery_first_name|string|null: false|送付先名前||
+|zip|string|null: false,limit: 8|郵便番号|郵便番号用のバリデーション要|
+|prefectures|string|null: false|都道府県|フォームで選択式にする|
+|municipality|string|null: false|市区町村||
+|address|string|null: false|番地||
+|building_name|string||マンション名やビル名・部屋号室等||
+|phone_number|string||お届け先電話番号|電話番号用のバリデーション要|
+|buyed_items|integer|null: false, foreign_key: "buyer_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
+|sailing_items|integer|-> { where("buyer_id is NULL")}, foreign_key: "saler_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
+|sold_items|integer|-> { where("buyer_id is not NULL")}, foreign_key: "saler_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
 
-Things you may want to cover:
+### Association
+- has_many :cards, dependent: :destroy
+- has_many :buyed_items
+- has_many :sailing_items
+- has_many :sold_items
 
-* Ruby version
+## cardsテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|customer_id|string|null: false|payjpの顧客id||
+|card_id|string|null: false|payjpのデフォルトカードid||
+|user_id|integer|null: false, foreign_key: true|Userとの外部キー||
 
-* System dependencies
+### Association
+- belongs_to :user
 
-* Configuration
+## itemsテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|name|string|null: false|商品名||
+|text|text|null: false|商品説明||
+|status|string|null: false|商品の状態|フォームで選択式にする|
+|shipping_charges|string|null: false|配送料の負担|フォームで選択式にする|
+|shipping_area|string|null: false|発送元の地域|フォームで選択式にする|
+|days_to_ship|string|null: false|発送までの日数|フォームで選択式にする|
+|price|integer|null: false|価格|半角のみにバリデーション要|
+|photo_id|integer|null: false, foreign_key: true|Photoとの外部キー||
+|brand_id|integer|null: false, foreign_key: true|Brandとの外部キー||
+|category_id|integer|null: false, foreign_key: true|Categoryとの外部キー||
+|saler_id|integer|null: false, foreign_key: true, class_name: "User"|Userとの外部キー|実装難しそう|
+|buyer_id|integer|null: false, foreign_key: true, class_name: "User"|Userとの外部キー|実装難しそう|
 
-* Database creation
+### Association
+- has_many :photos, dependent: :destroy
+- belongs_to :category
+- belongs_to :brand
+- belongs_to :saler
+- belongs_to :buyer
 
-* Database initialization
 
-* How to run the test suite
+## photosテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|url|string||写真のURL|1枚は必須かつ5枚まで登録可能(2枚目以降は任意)なバリデーション要|
+|item_id|integer|null: false, foreign_key: true|Itemとの外部キー||
 
-* Services (job queues, cache servers, search engines, etc.)
+### Association
+- belongs_to :item
 
-* Deployment instructions
+## brandsテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|name|string||ブランド名|seedでブランド名を事前に流し込み、フォームで選択式にさせる。indexを貼る|
+|item_id|integer|null: false, foreign_key: true|Itemとの外部キー||
 
-* ...
+### Association
+- has_many :items
+
+## categorysテーブル
+|Column|Type|Options|Meaning|attention|
+|------|----|-------|-------|---------|
+|name|string||カテゴリー名|seedでカテゴリー名を事前に流し込み、フォームで選択式にさせる。indexを貼る|
+|ancestry|string||親子孫識別|ancestry gemを用いる|
+|item_id|integer|null: false, foreign_key: true|Itemとの外部キー||
+
+### Association
+- has_many :items

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@
 |address|string|null: false|番地||
 |building_name|string||マンション名やビル名・部屋号室等||
 |phone_number|string||お届け先電話番号|電話番号用のバリデーション要|
-|buyed_items|integer|null: false, foreign_key: "buyer_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
-|sailing_items|integer|-> { where("buyer_id is NULL")}, foreign_key: "saler_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
-|sold_items|integer|-> { where("buyer_id is not NULL")}, foreign_key: "saler_id", class_name: "Item"|Itemとの外部キー|実装難しそう|
+
 
 ### Association
 - has_many :cards, dependent: :destroy
-- has_many :buyed_items
-- has_many :sailing_items
-- has_many :sold_items
+- has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
+- has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"
+- has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Item"
 
 ## cardsテーブル
 |Column|Type|Options|Meaning|attention|


### PR DESCRIPTION
# メンターi-date様
# WHAT 
【前回のコードレビューに対するフィードバック】
https://github.com/yusuke22an/furima-app/pull/3/commits/2b0804ce64088a408f5b74911be4a2036f66121d

【対応したこと】
①dependent: :destroyの追記
②brandテーブルのアソシエーションをhas_many itemsに修正

# WHY
上記はフィードバックに基づき、修正。
アドレステーブルをどうするかについては、
①これが本物のサービスだった場合、テーブルは細かく分けておいたほうが後々の修正がしやすいから
②ひとつのテーブルにあまりカラムが多いと、操作性の悪化などにつながるから
の２点だと推測するが、このままでも進められるため今回の作成では修正しない方向でチーム決定。

二つ目と三つ目のFBは、以下の参考記事を元に設計をし、
念のためメンターの岩本 一樹さんにも質問させていただいたがこのやり方でも実装できるとの見解を頂いた。
ただ、こちらも修正しない方向で進めようとチーム決定したいが、念のため見解をいただきたい。
（あとでやっぱり出来ませんでした、は辛いので）

【参考記事】
https://qiita.com/YosukeItabashi/items/2ed5cad13263410f0fbc

この記事によると、UserテーブルとItemテーブルに外部キー設定とMySQL条件式を記述することで中間テーブルを持たない作り方ができるようです。
この点について、メンターさんからの指摘は中間テーブルを作成することを前提とされていると推測しているのですが、
参考記事に基づくDB設計では何か不具合出てしまうのでしょうか。

# question
「dependent: :destroy」をREADMEに事前に記載する必要があることをレビューをいただき学習しました。関連して、READMEに「dependent: :destroy」を記載するのであれば「accepts_nested_attributes_for」も記載する必要があると考えました。
今回のレビューでは「dependent: :destroy」の追記のみいただきましたが、
それはform_withを使う場合は「accepts_nested_attributes_for」は必要ないからという理解でよろしいでしょうか。