### PR TITLE
item詳細ページの移行（furima→item）,furimaのコントローラーとビューのファイル削除

### DIFF
--- a/app/controllers/furima_controller.rb
+++ b/app/controllers/furima_controller.rb
@@ -1,4 +1,0 @@
-class FurimaController < ApplicationController
-  def index
-  end
-end

--- a/app/views/furima/index.html.haml
+++ b/app/views/furima/index.html.haml
@@ -1,4 +1,0 @@
-%title Team S !!
-%link{:href => "stylesheets/furima.scss", :rel => "stylesheet"}/
-%h1 Hello Team S !!
-%p 楽しく頑張って行きましょう！

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,5 @@
 = render "layouts/header"
 
-
 %body
   %nav.breadCrumbs
     %ul


### PR DESCRIPTION
# WHAT
商品詳細ページのファイルを、furimaディレクトリから、itemディレクトリへ移行した。
不要になったfurimaコントローラーとビューの削除を行った。

# WHY
仮で使用してディレクトリなので、整理することが目的。
今後の実装時にディレクトリ管理が必須だから。