### PR TITLE
furimaのルーティング削除、商品詳細のitemsコントローラーにshowを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,10 @@ class ItemsController < ApplicationController
     @category_grandchildren = Category.where('ancestry LIKE ?', "%/#{params[:child_id]}")
   end
 
+  def show
+    @categories = Category.all
+  end
+
 private
   def create_params
     params.require(:item).permit(:name, :text, :category_id, :brand_name, :status, :shipping_charges, :shipping_area, :days_to_ship, :price, photos:[]).merge(saler_id: current_user.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
   end
   resources :comments
   root 'items#index'
-  resources :furima
 
   resources :card, only: [:new, :show, :destroy] do
     collection do


### PR DESCRIPTION
# WHAT
furimaのルーティング削除
商品詳細のitemsコントローラーにshowを追加

# WHY
furimaのルーティングが不要となったため。
商品詳細画面へのshowアクションが必要なため。