### PR TITLE
出品した商品の購入の実装、cardとuserのアソシエーションの実装

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,4 +1,5 @@
 class PurchaseController < ApplicationController
+  before_action :set_item, only: [:index, :pay, :done]
   require 'payjp'
 
   def index
@@ -24,14 +25,20 @@ class PurchaseController < ApplicationController
       redirect_to controller: "card", action: "new"
       flash[:notice] = '購入失敗です。カード登録の確認をして下さい.'
     elsif Payjp::Charge.create(
-      amount: "328000", #支払金額を入力（itemテーブル等に紐づけても良い）
+      amount: @item.price, #"328000", #支払金額を入力（itemテーブル等に紐づけても良い）
       customer: card.customer_id, #顧客ID
       currency: 'jpy', #日本円
     )
+      @item.update(buyer_id: current_user.id)
       redirect_to action: 'done' #完了画面に移動
     else
       redirect_to action: "index" 
       flash[:notice] = '購入に失敗しました.'
     end
+  end
+  private
+
+  def set_item
+    @item = Item.find(params[:item_id])
   end
 end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -25,11 +25,15 @@ class PurchaseController < ApplicationController
       redirect_to controller: "card", action: "new"
       flash[:notice] = '購入失敗です。カード登録の確認をして下さい.'
     elsif Payjp::Charge.create(
-      amount: @item.price, #"328000", #支払金額を入力（itemテーブル等に紐づけても良い）
+      amount: @item.price,  #支払金額を入力（itemテーブル等に紐づけても良い）
       customer: card.customer_id, #顧客ID
       currency: 'jpy', #日本円
     )
-      @item.update(buyer_id: current_user.id)
+      if @item.update(buyer_id: current_user.id)
+        flash[:notice] = 'Event was successfully updated.'
+      else
+        flash[:notice] = '失敗しました。確認して下さい。'
+      end
       redirect_to action: 'done' #完了画面に移動
     else
       redirect_to action: "index" 
@@ -37,7 +41,7 @@ class PurchaseController < ApplicationController
     end
   end
 
-  
+
   private
 
   def set_item

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -36,6 +36,8 @@ class PurchaseController < ApplicationController
       flash[:notice] = '購入に失敗しました.'
     end
   end
+
+  
   private
 
   def set_item

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,2 +1,3 @@
 class Card < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  # has_many :cards, dependent: :destroy
+  has_many :cards #dependent: :destroy
   has_many :items
   has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
   has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :cards #dependent: :destroy
+  has_many :cards 
   has_many :items
   has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
   has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -1,3 +1,5 @@
+= render 'layouts/notifications'
+
 %label 登録クレジットカード情報
 %br
 = "**** **** **** " + @default_card_information.last4

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,5 +9,4 @@
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body
-    = render 'layouts/notifications'
     = yield

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,3 +1,5 @@
+= render 'layouts/notifications'
+
 %h2 購入が完了しました！
 %p Apple MacBook Pro executive 13インチ
 %p ¥328,000(送料込み)

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,5 +1,8 @@
 = render 'layouts/notifications'
+-# - binding.pry
 
 %h2 購入が完了しました！
-%p Apple MacBook Pro executive 13インチ
-%p ¥328,000(送料込み)
+-# %p Apple MacBook Pro executive 13インチ
+-# %p ¥328,000(送料込み)
+%p= @item.name
+%p= (" #{@item.price} 円です")

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,7 +1,6 @@
 = render 'layouts/notifications'
 
 %h2 購入が完了しました！
--# %p Apple MacBook Pro executive 13インチ
--# %p ¥328,000(送料込み)
+
 %p= @item.name
 %p= (" #{@item.price} 円です")

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,5 +1,4 @@
 = render 'layouts/notifications'
--# - binding.pry
 
 %h2 購入が完了しました！
 -# %p Apple MacBook Pro executive 13インチ

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,3 +1,5 @@
+= render 'layouts/notifications'
+
 %h2 購入を確定しますか？
 %p Apple MacBook Pro executive 13インチ
 %p ¥328,000(送料込み)

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,8 +1,10 @@
 = render 'layouts/notifications'
 
 %h2 購入を確定しますか？
-%p Apple MacBook Pro executive 13インチ
-%p ¥328,000(送料込み)
+%p= @item.name
+%p= (" #{@item.price} 円です")
+-# %p Apple MacBook Pro executive 13インチ
+-# %p ¥328,000(送料込み)
 %br
 %h3 支払い方法
 - if @default_card_information.blank?

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -3,8 +3,7 @@
 %h2 購入を確定しますか？
 %p= @item.name
 %p= (" #{@item.price} 円です")
--# %p Apple MacBook Pro executive 13インチ
--# %p ¥328,000(送料込み)
+
 %br
 %h3 支払い方法
 - if @default_card_information.blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,5 @@
 Rails.application.routes.draw do
-  # get 'purchase/index'
-  # get 'purchase/done'
-  # get 'card/new'
-  # get 'card/show'
+
   devise_for :users
   resources :users, only: :show
   resources :items do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  get 'purchase/index'
-  get 'purchase/done'
-  get 'card/new'
-  get 'card/show'
+  # get 'purchase/index'
+  # get 'purchase/done'
+  # get 'card/new'
+  # get 'card/show'
   devise_for :users
   resources :users, only: :show
   resources :items do
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
+    end
+    resources :purchase, only: [:index] do
+      collection do
+        post 'pay', to: 'purchase#pay'
+        get 'done', to: 'purchase#done'
+      end
     end
   end
   resources :comments
@@ -21,11 +27,5 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :purchase, only: [:index] do
-    collection do
-      post 'pay', to: 'purchase#pay'
-      get 'done', to: 'purchase#done'
-    end
-  end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
# WHAT
ルーティングの設定　itemsにpurchaseをネストさせた。

purchaseコントローラーの記述
　出品したitemのデータをsqlから取り出せるように記述した。
　https://gyazo.com/25cbb0634ff82a904d2d0cb87c01a6c7
　https://gyazo.com/861a5ecb27b31ae147a1b57201a758ef
　商品購入後に、そのitemのbuyer_id カラムに 購入者(current_user.id)を送る記述をした。
　https://gyazo.com/1da88d7a093161fc5e06e4839ecd34cb
　https://gyazo.com/118c47b815cb57933cee2c49dc4cad21
　itemのデータの取り出しについては、before_actionを使いリファクタリングをした。

payjpのコンソールにも反映されていることの確認済み
https://gyazo.com/e396e2e7778710efc9a695c403b89991

purchaseのビュー(index, done )に購入した商品が反映されるように、コントローラー側でインスタンス変数を定義した。

cardモデル(belongs_to :user)とuserモデル(has_many :cards )のアソシエーションを設定した。

# WHY
商品購入することで、商品の状態を変えるため（売り物→売り切れ、表示されないなど）
それに伴いビューも変更。

db設計に沿い、userとcardモデルを関連づけた。