### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/assets/javascripts/notice.js
+++ b/app/assets/javascripts/notice.js
@@ -1,0 +1,4 @@
+//noticeをhide
+$(document).ready(function() {
+  $('.notifications').fadeOut(4000);
+});

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -169,7 +169,7 @@
     }
   }
   &__feature {
-    margin: 60px 100px 60px 100px;
+    margin: 60px 100px 0 100px;
     &__title {
       font-size: 27px;
       text-align: center;

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -1,14 +1,15 @@
 .mypage {
+  width: 1020px;
+  margin: 0 auto 0 auto;
   padding: 40px 0 0 0;
   background-color: rgb(245, 245, 245);
   &__container {
-    margin: 0 auto 0 auto;
-    width: 1020px;
     padding: 0 0 40px 0;
     display: flex;
     flex-direction: row-reverse;
     &__right {
       width: 700px;
+      margin: 0 40px 0 0;
       &__user {
         height: 200px;
         padding: 20px 20px 20px 20px;

--- a/app/assets/stylesheets/_notice.scss
+++ b/app/assets/stylesheets/_notice.scss
@@ -1,0 +1,8 @@
+//notice(item削除等後簡易メッセージ)用
+.notifications {
+  background-color: $FRM-GRN;
+  .notice {
+    color: $TEXT-WT;
+    padding: 0 0 0 10px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 
 @import "./header";
 @import "./footer";
+@import "./notice";
 
 @import "./main";
 @import "./mypage";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
 
+  # 商品一覧表示(トップページ)用のアクション
   def index
     @categories = Category.all
     @items = Item.where(buyer_id: nil).order("created_at DESC").limit(6)
@@ -35,6 +36,7 @@ class ItemsController < ApplicationController
     @category_grandchildren = Category.where('ancestry LIKE ?', "%/#{params[:child_id]}")
   end
 
+  # 商品詳細表示用のアクション
   def show
     @categories = Category.all
     @item = Item.find(params[:id])
@@ -51,7 +53,13 @@ class ItemsController < ApplicationController
       @child = @item.category.parent.name
       @grand_child = @item.category.name
     end
+  end
 
+  # 商品削除用のアクション
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to user_path(current_user), notice: "商品名「#{item.name}」を削除しました。"
   end
 
 private

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -85,19 +85,20 @@
           様々な支払いに対応
         .main__feature__details__set__text
           お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
-  .main__pickup
-    .main__pickup__title
-      新規投稿商品
-    .main__pickup__bar
-    .main__pickup__box
-      .main__pickup__box__items
-        - @items.each do |item|
-          .main__pickup__box__items__item
-            .main__pickup__box__items__item__picture
-              = link_to item_path(item) do
-                = image_tag item.photos[0].variant(auto_orient: true), class: 'main__pickup__box__items__item__picture__img'
-            .main__pickup__box__items__item__list
-              .main__pickup__box__items__item__list__name
-                = item.name
-              .main__pickup__box__items__item__list__price
-                = "#{item.price}円"
+  - if @items.present?
+    .main__pickup
+      .main__pickup__title
+        新規投稿商品
+      .main__pickup__bar
+      .main__pickup__box
+        .main__pickup__box__items
+          - @items.each do |item|
+            .main__pickup__box__items__item
+              .main__pickup__box__items__item__picture
+                = link_to item_path(item) do
+                  = image_tag item.photos[0].variant(auto_orient: true), class: 'main__pickup__box__items__item__picture__img'
+              .main__pickup__box__items__item__list
+                .main__pickup__box__items__item__list__name
+                  = item.name
+                .main__pickup__box__items__item__list__price
+                  = "#{item.price}円"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -88,7 +88,8 @@
                 %i.fa.fa-comment
                 = link_to "この商品を購入する", item_buy_item_path(@item)
         .relatedItems
-          = link_to "削除"
-          = link_to "編集"
+          - if user_signed_in? && current_user.id == @item.saler_id
+            = link_to "削除", @item, method: :delete, data: { confirm: "商品名「#{@item.name}」を削除します。よろしいですか？"}
+            = link_to "編集"
    
 = render "layouts/footer"

--- a/app/views/layouts/_notice.html.haml
+++ b/app/views/layouts/_notice.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,4 @@
+= render "layouts/notice"
 = render "layouts/header"
 = render "mypage"
 = render "layouts/footer"


### PR DESCRIPTION
# What
商品削除機能の実装を行った
商品詳細ページ(items#show)の削除ボタンから削除可能。
商品を投稿したユーザーのみ、削除ボタンを表示させるように実装。

# Why
間違えて商品登録してしまうこともある為

https://i.gyazo.com/cc91192f2a6d51f33e978e14c9fb67a8.gif