### PR TITLE
出品者は詳細画面から購入画面に遷移できず、商品の編集、削除に遷移するための実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -51,7 +51,6 @@ class ItemsController < ApplicationController
       @child = @item.category.parent.name
       @grand_child = @item.category.name
     end
-
   end
 
 private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,9 +80,9 @@
                     = link_to "不適切な商品の通報"
           .commentBox
             %ul.commentContents
-            %form#new_comment.new_comment{"accept-charset" => "UTF-8", :action => "#", :method => "post"}
-              %input{:name => "utf8", :type => "hidden", :value => "✓"}/
-              %input{:name => "authenticity_token", :type => "hidden", :value => "1Bczt4lOo7JAdERX2XtCK8vhfifm8Ctxvh39Whs+Okki9MrIKVRqTBeFPZKZJYApdVTQaD4+C7APAiU25/MzZA=="}/
+            %form#new_comment.new_comment{"accept-charset": "UTF-8", action: "#", method: "post"}
+              %input{name: "utf8", type: "hidden", value: "✓"}/
+              %input{name: "authenticity_token", type: "hidden", value: "1Bczt4lOo7JAdERX2XtCK8vhfifm8Ctxvh39Whs+Okki9MrIKVRqTBeFPZKZJYApdVTQaD4+C7APAiU25/MzZA=="}/
               %br/
               -if user_signed_in? && current_user.id == @item.saler_id 
                
@@ -90,7 +90,7 @@
                   = link_to "編集"
                   = link_to "削除"
               -else 
-                %button.commentBtn{:name => "button", :type => "submit"}
+                %button.commentBtn{name: "button", type: "submit"}
                   %i.fa.fa-comment
                     = link_to "この商品を購入する", item_buy_item_path(@item)
             

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -84,11 +84,16 @@
               %input{:name => "utf8", :type => "hidden", :value => "✓"}/
               %input{:name => "authenticity_token", :type => "hidden", :value => "1Bczt4lOo7JAdERX2XtCK8vhfifm8Ctxvh39Whs+Okki9MrIKVRqTBeFPZKZJYApdVTQaD4+C7APAiU25/MzZA=="}/
               %br/
-              %button.commentBtn{:name => "button", :type => "submit"}
-                %i.fa.fa-comment
-                = link_to "この商品を購入する", item_buy_item_path(@item)
-        .relatedItems
-          = link_to "削除"
-          = link_to "編集"
+              -if user_signed_in? && current_user.id == @item.saler_id 
+               
+                .relatedItems
+                  = link_to "編集"
+                  = link_to "削除"
+              -else 
+                %button.commentBtn{:name => "button", :type => "submit"}
+                  %i.fa.fa-comment
+                    = link_to "この商品を購入する", item_buy_item_path(@item)
+            
+             
    
 = render "layouts/footer"


### PR DESCRIPTION
# What
出品者は詳細画面から購入画面に遷移できず、商品の編集、削除に遷移するための実装
ビューで、if文を使い条件分岐した。

# why
出品者が商品の編集、削除ができる必要があり、出品者以外は編集、削除できないようにするため。
また、出品者自身が自身の商品を購入できないようにするため。

ユーザーログイン時
https://gyazo.com/9dcac21c8d36a1ecb55e390a7674b27b

ユーザーサインアウト時
https://gyazo.com/e34b8dd9f43096979c546c6ea7ce0640