### PR TITLE
【コードレビューをお願いします】商品出品時の画像プレビュー表示実装

### DIFF
--- a/app/assets/javascripts/new_pict.js
+++ b/app/assets/javascripts/new_pict.js
@@ -18,7 +18,7 @@ $(function(){
 
       var num = $('.item-image').length + 1 + i
       fileReader.readAsDataURL(file);
-      //画像が10枚になったら超えたらドロップボックスを削除する
+      //画像が5枚になったら超えたらドロップボックスを削除する
       if (num == 5){
         $('#image-box__container').css('display', 'none')   
       }

--- a/app/assets/javascripts/new_pict.js
+++ b/app/assets/javascripts/new_pict.js
@@ -1,0 +1,75 @@
+$(function(){
+  //DataTransferオブジェクトで、データを格納する箱を作る
+  var dataBox = new DataTransfer();
+  //querySelectorでfile_fieldを取得
+  var file_field = document.querySelector('input[type=file]')
+  //fileが選択された時に発火するイベント
+  $('#img-file').change(function(){
+    //選択したfileのオブジェクトをpropで取得
+    var files = $('input[type="file"]').prop('files')[0];
+    $.each(this.files, function(i, file){
+      //FileReaderのreadAsDataURLで指定したFileオブジェクトを読み込む
+      var fileReader = new FileReader();
+
+      //DataTransferオブジェクトに対して、fileを追加
+      dataBox.items.add(file)
+      //DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に代入
+      file_field.files = dataBox.files
+
+      var num = $('.item-image').length + 1 + i
+      fileReader.readAsDataURL(file);
+      //画像が10枚になったら超えたらドロップボックスを削除する
+      if (num == 5){
+        $('#image-box__container').css('display', 'none')   
+      }
+      //読み込みが完了すると、srcにfileのURLを格納
+      fileReader.onloadend = function() {
+        var src = fileReader.result
+        var html= `<div class='item-image' data-image="${file.name}">
+                    <div class=' item-image__content'>
+                      <div class='item-image__content--icon'>
+                        <img src=${src} width="114" height="114" >
+                      </div>
+                    </div>
+                    <div class='item-image__operetion'>
+                      <div class='item-image__operetion--delete'>削除</div>
+                    </div>
+                  </div>`
+        //image_box__container要素の前にhtmlを差し込む
+        $('#image-box__container').before(html);
+      };
+      //image-box__containerのクラスを変更し、CSSでドロップボックスの大きさを変えてやる。
+      $('#image-box__container').attr('class', `item-num-${num}`)
+    });
+  });
+  //削除ボタンをクリックすると発火するイベント
+  $(document).on("click", '.item-image__operetion--delete', function(){
+    //削除を押されたプレビュー要素を取得
+    var target_image = $(this).parent().parent()
+    //削除を押されたプレビューimageのfile名を取得
+    var target_name = $(target_image).data('image')
+    //プレビューがひとつだけの場合、file_fieldをクリア
+    if(file_field.files.length==1){
+      //inputタグに入ったファイルを削除
+      $('input[type=file]').val(null)
+      dataBox.clearData();
+      console.log(dataBox)
+    }else{
+      //プレビューが複数の場合
+      $.each(file_field.files, function(i,input){
+        //削除を押された要素と一致した時、index番号に基づいてdataBoxに格納された要素を削除する
+        if(input.name==target_name){
+          dataBox.items.remove(i) 
+        }
+      })
+      //DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に再度代入
+      file_field.files = dataBox.files
+    }
+    //プレビューを削除
+    target_image.remove()
+    //image-box__containerクラスをもつdivタグのクラスを削除のたびに変更
+    var num = $('.item-image').length
+    $('#image-box__container').show()
+    $('#image-box__container').attr('class', `item-num-${num}`)
+  })
+});

--- a/app/assets/stylesheets/_sell_item.scss
+++ b/app/assets/stylesheets/_sell_item.scss
@@ -64,29 +64,39 @@
               margin: 0;
               padding-bottom: 40px;
               width: 100%;
-              .pict-uploader{
+              .image-box-1{
                 display: flex;
-                background: #f5f5f5;
+                width: 100%;
+                border: 2px dotted #888;
                 transition: box-shadow ease-out .3s;
-                padding: 10px;
- 
-                .sell-upload-pict{
-                  position: relative;
-                  min-height: 142px;
-                  border: 1px dashed #ccc;
-                  font-size: 0;
-                  justify-content: space-between;
-                  margin:10px;
-                  background-color: gray;
-                  width: 100px;
-                  align-items: center;
-                  i{
-                    position: absolute;
-                    font-size: 20px;
-                  }
-                  .file-upload{
-                  }
+                padding: 5px;
+                min-height: 150px;
+                text-align: center;
+                align-items: center;
+                justify-content: space-around;
+                .item-image{
+                  border: 1px solid #888;
+                  background-color: #fff;
                 }
+                .item-image__operetion--delete{
+                  color: #0099e8; 
+                  cursor: default;
+                }
+                .item-num-0{
+                  width: 100%;
+                }
+                .item-num-1{
+                  width: 491px;
+                }
+                .item-num-2{
+                  width: 363px;
+                }
+                .item-num-3{
+                  width: 234px;
+                }
+                .item-num-4{
+                  width: 106px;
+                }  
               }
               .input-default{
                 width: 100%;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,9 +8,14 @@ class ItemsController < ApplicationController
 
   # 商品出品用のアクション
   def new
-    @item = Item.new    
-    @category_parent_array = Category.where(ancestry: nil).each do |parent|
+    if user_signed_in?
+      @item = Item.new    
+      @category_parent_array = Category.where(ancestry: nil).each do |parent|
+      end
+    else
+      redirect_to new_user_session_path
     end
+
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,7 @@ class ItemsController < ApplicationController
 
   end
 
+  # 商品出品時のデータ保存用アクション
   def create
     @item = Item.new(create_params)
     if @item.save
@@ -33,6 +34,7 @@ class ItemsController < ApplicationController
   def update
   end
 
+  # 商品出品時のカテゴリー取得に仕様
   def get_category_children
     @category_children = Category.where('ancestry = ?', "#{params[:parent_name]}")
   end
@@ -68,6 +70,7 @@ class ItemsController < ApplicationController
   end
 
 private
+  # 商品投稿時のparams
   def create_params
     params.require(:item).permit(:name, :text, :category_id, :brand_name, :status, :shipping_charges, :shipping_area, :days_to_ship, :price, photos:[]).merge(saler_id: current_user.id)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,8 +10,7 @@ class ItemsController < ApplicationController
   def new
     if user_signed_in?
       @item = Item.new    
-      @category_parent_array = Category.where(ancestry: nil).each do |parent|
-      end
+      @category_parent_array = Category.where(ancestry: nil)
     else
       redirect_to new_user_session_path
     end
@@ -24,8 +23,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to controller: :users, action: :show, id: current_user.id
     else
-      @category_parent_array = Category.where(ancestry: nil).each do |parent|
-      end
+      @category_parent_array = Category.where(ancestry: nil)
       render :new, notice: "fail"
     end        
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(create_params)
     if @item.save
-        redirect_to root_path,notice: "投稿完了しました"
+      redirect_to controller: :users, action: :show, id: current_user.id
     else
       @category_parent_array = Category.where(ancestry: nil).each do |parent|
       end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,7 @@ class Item < ApplicationRecord
   has_many_attached :photos
 
   validates :photos, presence: true,length:{ minimum: 1} 
+
   validates :name, presence: true
   validates :text, presence: true, length:{ maximum: 1000}
   validates :status, presence: true

--- a/app/views/items/_sell_item.html.haml
+++ b/app/views/items/_sell_item.html.haml
@@ -23,23 +23,23 @@
               .pict-uploader
                 .sell-upload-pict
                   = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload',multiple: true
+                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
                   %br
                 .sell-upload-pict
                   = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload',multiple: true
+                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
                   %br                
                 .sell-upload-pict
                   = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload',multiple: true
+                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
                   %br                
                 .sell-upload-pict
                   = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload',multiple: true
+                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
                   %br                
                 .sell-upload-pict
                   = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload',multiple: true
+                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
                   %br                
 
           .contents

--- a/app/views/items/_sell_item.html.haml
+++ b/app/views/items/_sell_item.html.haml
@@ -11,7 +11,6 @@
         = form_with model: @item, local: true do |f|
           - if @item.errors.any?
             %ul
-              - # errorsに入っているエラー内容を出力する
               - @item.errors.full_messages.each do |message|
                 %li= message
 
@@ -20,27 +19,11 @@
               %label.pict(for="pict")出品画像
               %span.form-require 必須
               %p.pict-caution 最大5枚までアップロードできます
-              .pict-uploader
-                .sell-upload-pict
-                  = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
-                  %br
-                .sell-upload-pict
-                  = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
-                  %br                
-                .sell-upload-pict
-                  = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
-                  %br                
-                .sell-upload-pict
-                  = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
-                  %br                
-                .sell-upload-pict
-                  = icon('fas', 'image', class: 'icon')
-                  =f.file_field :photos,class: 'file-upload', accept: 'image/jpeg,image/gif,image/png',multiple: true
-                  %br                
+              .image-box-1
+                .item-num-0#image-box__container
+                  = f.file_field :photos, type: 'file',class: 'file-upload', accept: 'image/jpeg,image/gif,image/png', value:"", style: "display:none", id:"img-file" ,multiple: true
+                  %label{for: "img-file"}
+                    %i.fas.fa-camera
 
           .contents
             .form-group


### PR DESCRIPTION
# WHAT
・商品出品における画像選択時のプレビュー表示機能および削除機能を実装
・ログインユーザーのみ商品出品ができ、非ログインユーザーは出品ボタンを押してもサインインページへ遷移させる仕様を追加
・商品出品完了後はマイページへ遷移させる仕様に変更
・その他、微調整

# WHY
・出品商品どの画像を選択したかわからないとユーザービリティが落ちるから
・ログインユーザーのみサイトを使える仕様にする必要があったから
・投稿後はマイページに遷移する方が自然だから

【画像貼付】
[![Image from Gyazo](https://i.gyazo.com/8d1fddf005c1efdc317b49af13d8c0d2.gif)](https://gyazo.com/8d1fddf005c1efdc317b49af13d8c0d2)

【貼付けた画像の削除】
[![Image from Gyazo](https://i.gyazo.com/63b022b3937f83ef38313c4d6e4543d3.gif)](https://gyazo.com/63b022b3937f83ef38313c4d6e4543d3)

【投稿完了後のマイページへの遷移】
[![Image from Gyazo](https://i.gyazo.com/c5db083192c5fe00be1589e9ee8425ff.gif)](https://gyazo.com/c5db083192c5fe00be1589e9ee8425ff)
