### PR TITLE
マイページ/サーバサイド実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,4 @@ gem 'ancestry'
 gem "nokogiri", ">= 1.10.8"
 
 gem 'payjp'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -348,6 +360,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -39,23 +39,63 @@
       }
       &__transaction {
         margin: 40px 0 0 0;
-        font-weight: 600;
         color: rgb(51, 51, 51);
         &__title {
+          font-weight: 600;
           padding: 0 16px 0 16px;
           background-color: rgb(250, 250, 250);
           font-size: 16px;
           line-height: 72px;
           border-bottom: 2px solid rgb(60, 202, 206);
         }
-        &__content {
-          background-color: rgb(255, 255, 255);
-          background-image: url("/logo.png");
-          background-repeat: no-repeat;
-          background-position: center 80px;
+        &__present {
+          background-color: $BACK-WHT;
+          &__items {
+            display: flex;
+            justify-content: space-evenly;
+            padding: 24px 24px 8px 24px;
+            &__item {
+              width: 180px;
+              &__picture {
+                width: 180px;
+                height: 180px;
+                object-fit: cover;
+                vertical-align: bottom;
+              }
+              &__list {
+                background-color: $BACK-WHT;
+                color: rgb(51, 51, 51);
+                padding: 16px;
+                &__name {
+                  overflow: hidden;
+                  line-height: 1.5;
+                  font-size: 16px;
+                  text-align: left;
+                }
+                &__price {
+                  font-size: 16px;
+                }
+              }
+            }
+          }
+
+
+
+
+
+
+
+        }
+        &__nil {
+          background-color: $BACK-WHT;
           margin: 0 0 10px 0;
+          &__image {
+            display: block;
+            margin: 0 auto;
+            padding: 100px 0 0 0;
+          }
           &__text {
-            padding: 160px 0 60px 0;
+            padding: 60px 0 60px 0;
             text-align: center;
           }
         }

--- a/app/assets/stylesheets/_pagination.scss
+++ b/app/assets/stylesheets/_pagination.scss
@@ -1,0 +1,4 @@
+.pagination {
+  text-align: right;
+  padding: 0 16px 16px 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "./header";
 @import "./footer";
 @import "./notice";
+@import "./pagination";
 
 @import "./main";
 @import "./mypage";

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,5 +4,8 @@ class UsersController < ApplicationController
   def show
     @categories = Category.all
     @user = User.find(current_user.id)
+    @ruikei_shuppin_items = Item.where(saler_id: current_user.id)
+    @shuppin_chu_items = Item.where(saler_id: current_user.id, buyer_id: nil).order(created_at: :desc).page(params[:shuppin_chu_page]).per(3)
+    @katta_items = Item.where(buyer_id: current_user.id).order(created_at: :desc).page(params[:katta_page]).per(3)
   end
 end

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -6,26 +6,64 @@
         .mypage__container__right__user__name
           = @user.nickname
         .mypage__container__right__user__exhibitions
-          出品数
+          累計出品数
           %span.mypage__container__right__user__exhibitions__number
-            0
+            = @ruikei_shuppin_items.length
       .mypage__container__right__transaction
         .mypage__container__right__transaction__title
-          購入した商品 -- 取引中
-        .mypage__container__right__transaction__content
-          .mypage__container__right__transaction__content__text
-            取引中の商品がありません
+          出品中の商品
+        - if @shuppin_chu_items.present?
+          .mypage__container__right__transaction__present
+            .mypage__container__right__transaction__present__items
+              - @shuppin_chu_items.each do |item|
+                .mypage__container__right__transaction__present__items__item
+                  = link_to item_path(item) do
+                    = image_tag item.photos[0].variant(auto_orient: true), class: 'mypage__container__right__transaction__present__items__item__picture'
+                  .mypage__container__right__transaction__present__items__item__list
+                    .mypage__container__right__transaction__present__items__item__list__name
+                      = item.name
+                    .mypage__container__right__transaction__present__items__item__list__price
+                      = "#{item.price}円"
+            = paginate(@shuppin_chu_items, param_name: 'shuppin_chu_page')
+        - else
+          .mypage__container__right__transaction__nil
+            = image_tag '/logo.png', class: "mypage__container__right__transaction__nil__image"
+            .mypage__container__right__transaction__nil__text
+              出品中の商品がありません
       .mypage__container__right__transaction
         .mypage__container__right__transaction__title
-          購入した商品 -- 過去の取引
-        .mypage__container__right__transaction__content
-          .mypage__container__right__transaction__content__text
-            過去に取引した商品がありません
+          購入した商品
+        - if @katta_items.present?
+          .mypage__container__right__transaction__present
+            .mypage__container__right__transaction__present__items
+              - @katta_items.each do |item|
+                .mypage__container__right__transaction__present__items__item
+                  = link_to "#" do
+                    = image_tag item.photos[0].variant(auto_orient: true), class: 'mypage__container__right__transaction__present__items__item__picture'
+                  .mypage__container__right__transaction__present__items__item__list
+                    .mypage__container__right__transaction__present__items__item__list__name
+                      = item.name
+                    .mypage__container__right__transaction__present__items__item__list__price
+                      = "#{item.price}円"
+            = paginate(@katta_items, param_name: 'katta_page')
+        - else
+          .mypage__container__right__transaction__nil
+            = image_tag '/logo.png', class: "mypage__container__right__transaction__nil__image"
+            .mypage__container__right__transaction__nil__text
+              過去に購入した商品がありません
+
+      -# .mypage__container__right__transaction
+      -#   .mypage__container__right__transaction__title
+      -#     購入した商品
+      -#   .mypage__container__right__transaction__nil
+      -#     = image_tag '/logo.png', class: "mypage__container__right__transaction__nil__image"
+      -#     .mypage__container__right__transaction__nil__text
+      -#       過去に購入した商品がありません
     .mypage__container__left
       .mypage__container__left__nav
         %ul.mypage__container__left__nav__list
           %li.mypage__container__left__nav__list__item--active
-            = link_to "#", class: "mypage__container__left__nav__list__item__a" do
+            = link_to user_path(current_user), class: "mypage__container__left__nav__list__item__a" do
               マイページ
             = icon 'fas', 'fas fa-chevron-right', class: "mypage__container__left__nav__list__item__arrow"
           %li.mypage__container__left__nav__list__item
@@ -33,8 +71,8 @@
               出品する
             = icon 'fas', 'fas fa-chevron-right', class: "mypage__container__left__nav__list__item__arrow"
           %li.mypage__container__left__nav__list__item
-            = link_to "#", class: "mypage__container__left__nav__list__item__a" do
-              支払い方法
+            = link_to card_path(current_user), class: "mypage__container__left__nav__list__item__a" do
+              クレジットカード
             = icon 'fas', 'fas fa-chevron-right', class: "mypage__container__left__nav__list__item__arrow"
           %li.mypage__container__left__nav__list__item
             = link_to "#", class: "mypage__container__left__nav__list__item__a" do

--- a/app/views/users/_mypage.html.haml
+++ b/app/views/users/_mypage.html.haml
@@ -51,14 +51,6 @@
             = image_tag '/logo.png', class: "mypage__container__right__transaction__nil__image"
             .mypage__container__right__transaction__nil__text
               過去に購入した商品がありません
-
-      -# .mypage__container__right__transaction
-      -#   .mypage__container__right__transaction__title
-      -#     購入した商品
-      -#   .mypage__container__right__transaction__nil
-      -#     = image_tag '/logo.png', class: "mypage__container__right__transaction__nil__image"
-      -#     .mypage__container__right__transaction__nil__text
-      -#       過去に購入した商品がありません
     .mypage__container__left
       .mypage__container__left__nav
         %ul.mypage__container__left__nav__list


### PR DESCRIPTION
# What
マイページのサーバサイドを実装

■ 画面左側
　→ link_toを実装(登録情報編集は必須項目ではないのでリンク先は"#")

■ 画面右側
　→ 出品中の商品をkaminari gemを用い、一度に3件まで表示
　→ 購入した商品をkaminari gemを用い、一度に3件まで表示

# Why
ユーザーがアプリ内で登録している情報をひとまとめにし、ユーザビリティを高めたいから

![スクリーンショット 2020-03-17 20 34 58](https://user-images.githubusercontent.com/53374504/76852492-c7813580-688e-11ea-9684-ef4dbda000f7.png)

　