### PR TITLE
購入機能のコントローラーテストの再実装(mock)

### DIFF
--- a/spec/controllers/card_controller_spec.rb
+++ b/spec/controllers/card_controller_spec.rb
@@ -1,33 +1,33 @@
 # payjp(API)側のテストになってしまうため、コメントアウト。（itemのidを渡す前ではテストをパスした）
 
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe CardController, type: :controller do
+RSpec.describe CardController, type: :controller do
 
-#   let(:user) { create(:user) }
+  let(:user) { create(:user) }
 
-#   before do
-#     login user
-#   end
+  before do
+    login user
+  end
 
-#   describe "GET #new" do
-#     it "returns http success" do
-#       get :new
-#       expect(response).to have_http_status(:success)
-#     end
-#   end
+  describe "GET #new" do
+    it "returns http success" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
 
-#   describe "GET #show" do
-#     it "returns http success" do
-#       allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.prepare_customer_information)
-#       card = Card.create(
-#         user_id: user.id,
-#         customer_id: Payjp::Customer.create[:cards][:data][0][:customer],
-#         card_id: Payjp::Customer.create[:cards][:data][0][:id]
-#       )
-#       get :show, params: {id: card.id}
-#       expect(response).to have_http_status(:success)
-#     end
-#   end
+  describe "GET #show" do
+    it "returns http success" do
+      allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.prepare_customer_information)
+      card = Card.create(
+        user_id: user.id,
+        customer_id: Payjp::Customer.create[:cards][:data][0][:customer],
+        card_id: Payjp::Customer.create[:cards][:data][0][:id]
+      )
+      get :show, params: {id: card.id}
+      expect(response).to have_http_status(:success)
+    end
+  end
 
-# end
+end

--- a/spec/controllers/purchase_controller_spec.rb
+++ b/spec/controllers/purchase_controller_spec.rb
@@ -1,33 +1,30 @@
-# payjp(API)側のテストになってしまうため、コメントアウト。（itemのidを渡す前ではテストをパスした）
+require 'rails_helper'
 
+RSpec.describe PurchaseController, type: :controller do
 
-# require 'rails_helper'
+  let(:user) { create(:user) }
+  let(:item) { create(:item) }
 
-# RSpec.describe PurchaseController, type: :controller do
+  describe "GET #index" do
+    before do
+      login user
+    end
+    it "returns http success" do
+      allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.prepare_customer_information)
+      card = Card.create(
+        user_id: user.id,
+        customer_id: Payjp::Customer.create[:cards][:data][0][:customer],
+        card_id: Payjp::Customer.create[:cards][:data][0][:id]
+      )
+      get :index, params: { item_id: item.id }
+      expect(response).to have_http_status(:success)
+    end
+  end
 
-#   let(:user) { create(:user) }
-
-  # describe "GET #index" do
-  #   before do
-  #     login user
-  #   end
-  #   it "returns http success" do
-  #     allow(Payjp::Customer).to receive(:create).and_return(PayjpMock.prepare_customer_information)
-  #     card = Card.create(
-  #       user_id: user.id,
-  #       customer_id: Payjp::Customer.create[:cards][:data][0][:customer],
-  #       card_id: Payjp::Customer.create[:cards][:data][0][:id]
-  #     )
-  #     get :index
-  #     expect(response).to have_http_status(:success)
-  #   end
-  # end
-
-#   describe "GET #done" do
-#     it "returns http success" do
-#       get :done
-#       expect(response).to have_http_status(:success)
-#     end
-#   end
-
-# end
+  describe "GET #done" do
+    it "returns http success" do
+      get :done, params: { item_id: item.id }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   
   factory :user do
     nickname              {"やまたろ"}
-    email                 {"hoge@hoge.com"}
+    email                 {Faker::Internet.free_email}
     password              {"0000000"}
     password_confirmation {"0000000"}
     last_name             {"山田"}

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Card, type: :model do
-  # pending "add some examples to (or delete) #{__FILE__}"
-
-  #全項目
-  it "全ての項目が適切に入力されていれば登録できるテスト" do
-    card = build(:card)
-    expect(card).to be_valid
-  end
-
-
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/support/payjp_mock.rb
+++ b/spec/support/payjp_mock.rb
@@ -1,49 +1,45 @@
 module PayjpMock
   def self.prepare_customer_information # Payjp::Customerのレスポンスモック
     {
-      "id": "cus_e508f846181f5491fba3ee02692d",
+      "id": "cus_e508f846181f5491fba3ee02692d", #ここのidはなんでも良い mockのidだから。
       "cards": {
         "count":1,
         "data":[{
-          "id": "car_bf3087b2da1e4bdc6d3188f3b709",
-          "address_city": nil,
-          "address_line1":nil,
-          "address_line2":nil,
-          "address_state":nil,
-          "address_zip":nil,
-          "address_zip_check": "unchecked",
-          "brand": "Visa",
-          "country":nil,
-          "created": 1223830630,
-          "customer": "cus_e508f846181f5491fba3ee02692d",
-          "cvc_check": "passed",
-          "exp_month":02,
+          "id":"car_c91aa7d8ec85573dd4b4fdcfb99c", #ここのidはデータなので、dbと同じでないといけない。
+          "address_city":"",
+          "address_line1":"",
+          "address_line2":"",
+          "address_state":"",
+          "address_zip":"",
+          "address_zip_check":"unchecked",
+          "brand":"Visa",
+          "country":"",
+          "created":1584597777,
+          "customer":"cus_8241fab179982d39cd973023a2e1",  #ここのidはデータなので、dbと同じでないといけない。
+          "cvc_check":"passed",
+          "exp_month":2,
           "exp_year":2022,
-          "fingerprint": "e1d8225886e3a7211127df751c86787f",
-          "last4": "4242",
+          "fingerprint":"e1d8225886e3a7211127df751c86787f",
+          "last4":"4242",
           "livemode":false,
           "metadata":{},
-          "name":nil,
-          "object": "card"
+          "name":"",
+          "object":"card",
           }],
           "has_more":false,
-          "object": "list",
-          "url": "/v1/customers/cus_e508f846181f5491fba3ee02692d/cards"
+          "object":"list",
+          "url":"/v1/customers/cus_8241fab179982d39cd973023a2e1/cards",
         },
-      "created": 1223830631,
-      "default_card": "car_bf3087b2da1e4bdc6d3188f3b709",
-      "description": nil,
-      "email": nil,
+
+      "created": 1584597777,
+      "default_card": "car_c91aa7d8ec85573dd4b4fdcfb99c",
+      "description": "登録テスト",
+      "email": "test@gmail.com",
       "livemode": false,
-      "metadata": {},
+      "metadata": {"user_id":"1"},
       "object": "customer",
-      "subscriptions": {
-        "count":0,
-        "data":[],
-        "has_more":false,
-        "object": "list",
-        "url": "/v1/customers/cus_e508f846181f5491fba3ee02692d/subscriptions"
-      }
+      "subscriptions": {"count":0,"data":[],"has_more":false,"object":"list","url":"/v1/customers/cus_8241fab179982d39cd973023a2e1/subscriptions"},
     }
   end
 end
+


### PR DESCRIPTION
# WHAT
card_controller_spec.rbの実装
purchase_controller_spec.rbの実装
FactoryBot　user のemailに Fakerを使用
mockファイルの書き換え
不要になったmodelコントローラーの記述の削除

# WHY
「購入機能」が動く際の挙動をテストするため
コントローラーが想定通りに動いているか確認するため