### PR TITLE
編集失敗時のnoticeの追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,8 +67,7 @@ class ItemsController < ApplicationController
     if @item.update(create_params)
       redirect_to item_path(@item), notice: "商品名「#{@item.name}」の情報を更新しました。"
     else
-      redirect_to edit_item_path
-      # renderで表示できるよう修正予定
+      redirect_to edit_item_path, notice: "商品名「#{@item.name}」の情報を不足いています。"
     end
   end
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,1 +1,2 @@
+= render "layouts/notice"
 = render "sell_item"


### PR DESCRIPTION
# what
items_controllerのupdateアクションで、編集失敗時のnoticeの追加

# why
編集失敗時にメッセージが表示されるとユーザーに分かりやすいため

https://gyazo.com/ca468ff62130542cee2dc44fb423a89a