### PR TITLE
画像がない状態で商品が登録されてしまった場合のフォロー

### DIFF
--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -93,12 +93,13 @@
       .main__pickup__box
         .main__pickup__box__items
           - @items.each do |item|
-            .main__pickup__box__items__item
-              .main__pickup__box__items__item__picture
-                = link_to item_path(item) do
-                  = image_tag item.photos[0].variant(auto_orient: true), class: 'main__pickup__box__items__item__picture__img'
-              .main__pickup__box__items__item__list
-                .main__pickup__box__items__item__list__name
-                  = item.name
-                .main__pickup__box__items__item__list__price
-                  = "#{item.price}円"
+            - if item.photos[0]
+              .main__pickup__box__items__item
+                .main__pickup__box__items__item__picture
+                  = link_to item_path(item) do
+                    = image_tag item.photos[0].variant(auto_orient: true), class: 'main__pickup__box__items__item__picture__img'
+                .main__pickup__box__items__item__list
+                  .main__pickup__box__items__item__list__name
+                    = item.name
+                  .main__pickup__box__items__item__list__price
+                    = "#{item.price}円"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,7 +11,8 @@
           = @item.name
 
           .itemBox__body
-            = image_tag @item.photos[0].variant(auto_orient: true), class: 'itemBox__body__show__img'
+            - if @item.photos[0]
+              = image_tag @item.photos[0].variant(auto_orient: true), class: 'itemBox__body__show__img'
           .itemBox__price
             %span
               = ("#{@item.price} 円")


### PR DESCRIPTION
# what
items_indexとshowのビューにif文で条件分岐して、画像がなくても表示できるようにした。

# why
何らかの理由で画像がない状態の商品が登録された際にその商品を削除できるように。また、エラー画面を表示させずサービスを停止させないため。